### PR TITLE
Fix for deprecated PropTypes

### DIFF
--- a/Example/src/SignatureView.js
+++ b/Example/src/SignatureView.js
@@ -1,6 +1,8 @@
 import React, {
-  Component, PropTypes
+  Component
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import ReactNative, {
   View, Text, Modal, Platform, Alert

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -3,9 +3,7 @@
 
 var ReactNative = require('react-native');
 var React = require('react');
-var {
-    PropTypes
-} = React;
+var PropTypes = require('prop-types');
 var {
     requireNativeComponent,
     View,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "signature"
   ],
   "peerDependencies": {
-    "react-native": ">=0.40"
+    "react-native": ">=0.40",
+    "prop-types": "^15.5.10"
   },
   "author": "RepairShopr",
   "license": "ISC",


### PR DESCRIPTION
Importing PropTypes from the "react" module was deprecated in react 15.5. This fixes that.